### PR TITLE
Update k-g.cpp

### DIFF
--- a/src/conv/k-g.cpp
+++ b/src/conv/k-g.cpp
@@ -613,7 +613,7 @@ main(int argc, char **argv)
 	bu_exit(1, "Error: file %s already exists.\n", argv[1]);
     }
 
-    std::ifstream infile(argv[0]);
+    std::ifstream infile(argv[0], std::ios::binary);
     if (!infile.is_open()) {
 	bu_exit(1, "Error: unable to open %s for reading.\n", argv[0]);
     }


### PR DESCRIPTION
fixing a bug in the .key to .g converter, caused by ifstream::tellg() returning wrong position. the fix is specifying the file as binary when opening the input file.